### PR TITLE
Improve permissions to allow for increased granularity

### DIFF
--- a/menu_link_attributes.module
+++ b/menu_link_attributes.module
@@ -15,6 +15,7 @@ use Drupal\Component\Plugin\Exception\PluginNotFoundException;
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function menu_link_attributes_form_menu_link_content_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  $account = \Drupal::currentUser();
   $attributes = \Drupal::config('menu_link_attributes.config')->get('attributes') ?: [];
   $menu_link = $form_state->getFormObject()->getEntity();
   $menu_link_options = $menu_link->link->first()->options ?: [];
@@ -25,6 +26,7 @@ function menu_link_attributes_form_menu_link_content_form_alter(array &$form, Fo
     '#title' => t('Attributes'),
     '#weight' => -2,
     '#tree' => TRUE,
+    '#access' => $account->hasPermission('use menu link attributes'),
   ];
 
   $config_path = Url::fromRoute('menu_link_attributes.config')->toString();
@@ -39,13 +41,15 @@ function menu_link_attributes_form_menu_link_content_form_alter(array &$form, Fo
   $destination = \Drupal::destination()->getAsArray();
   $config_path = Url::fromRoute('menu_link_attributes.config', [], ['query' => $destination])->toString();
 
-  if (count($attributes)) {
-    $form['options']['attributes']['#description'] = '<small>' . t('Manage available attributes <a href="@config">here</a>.', ['@config' => $config_path]) . '</small>';
-  }
-  else {
-    $form['options']['attributes']['help'] = [
-      '#markup' => t('Manage available attributes <a href="@config">here</a>.', ['@config' => $config_path]),
-    ];
+  if ($account->hasPermission('administer menu link attributes')) {
+    if (count($attributes)) {
+      $form['options']['attributes']['#description'] = '<small>' . t('Manage available attributes <a href="@config">here</a>.', ['@config' => $config_path]) . '</small>';
+    }
+    else {
+      $form['options']['attributes']['help'] = [
+        '#markup' => t('Manage available attributes <a href="@config">here</a>.', ['@config' => $config_path]),
+      ];
+    }
   }
 
   $autofocus = FALSE;

--- a/menu_link_attributes.permissions.yml
+++ b/menu_link_attributes.permissions.yml
@@ -1,0 +1,7 @@
+administer menu link attributes:
+  title: 'Administer menu link attributes'
+  description: 'Provides administrative capabilities for configuring and complete use of Menu Link Attributes.'
+  restrict access: true
+use menu link attributes:
+  title: 'Allows use of menu link attributes'
+  description: 'Allows for the use of menu link attribute selection within the menu link create or edit forms.'

--- a/menu_link_attributes.routing.yml
+++ b/menu_link_attributes.routing.yml
@@ -4,4 +4,4 @@ menu_link_attributes.config:
     _form: '\Drupal\menu_link_attributes\Form\ConfigForm'
     _title: 'Menu link attributes'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer menu link attributes'


### PR DESCRIPTION
## Problem

We are making use of this contributed module within a large site build. One problem that we are encountering is the lack of granular permissions which restrict the access to Menu Link Attribute capabilities, both from a 'usage' and 'configuration' point of view.

## Solution

_This_ PR.