### PR TITLE
Support container attributes for nested menus

### DIFF
--- a/menu_link_attributes.module
+++ b/menu_link_attributes.module
@@ -174,7 +174,14 @@ function menu_link_attributes_is_container_attribute($attribute_name) {
  * Implements template_preprocess_menu().
  */
 function menu_link_attributes_preprocess_menu(&$variables) {
-  foreach ($variables['items'] as $item) {
+  _menu_link_attributes_preprocess_menu_items($variables['items']);
+}
+
+/**
+ * Helper function to recursively set list item attributes.
+ */
+function _menu_link_attributes_preprocess_menu_items(&$items) {
+  foreach ($items as $item) {
     /** @var \Drupal\Core\Menu\MenuLinkDefault $menu_link */
     $menu_link = $item['original_link'];
     $options = $menu_link->getOptions();
@@ -184,6 +191,9 @@ function menu_link_attributes_preprocess_menu(&$variables) {
       foreach ($options['container_attributes'] as $attribute => $value) {
         $item['attributes']->setAttribute($attribute, $value);
       }
+    }
+    if (!empty($item['below'])) {
+      _menu_link_attributes_preprocess_menu_items($item['below']);
     }
   }
 }


### PR DESCRIPTION
Container attributes currently only work for top-level `<li>` tags. 

So for example:
```
<ul>
  <li class="my-li">
    <a class="my-link" href="#">Whatever</a>
    <ul>
      <li>
        <a class="my-internal-link" href="#">Sublink</a>
      </li>
    </ul>
  </li>
</ul>
```

Presently there is no way to add a class to that nested `<li>`. 

This PR extends that support to submenus as well. 
```
<ul>
  <li class="my-li">
    <a class="my-link" href="#">Whatever</a>
    <ul>
      <li class="my-internal-li">
        <a class="my-internal-link" href="#">Sublink</a>
      </li>
    </ul>
  </li>
</ul>
```

It's worth noting, this could have performance impacts for sites with extremely large menus. I saw that similar functionality was removed in #30 for that very reason, so this may not be the best solution. 

If this could be presented as an optional setting in the admin panel that may help satisfy those who need a performant option that doesn't add attributes to nested `<li>` tags. 
