### PR TITLE
not allowing for to save empty target attribute as that isn't valid

### DIFF
--- a/menu_link_attributes.module
+++ b/menu_link_attributes.module
@@ -138,7 +138,10 @@ function menu_link_attributes_menu_link_content_form_submit($form, FormStateInte
   }
 
   foreach ($menu_link_attributes as $attribute_group => $attributes) {
-    $menu_link_attributes[$attribute_group] = array_filter($attributes);
+   if ($attributes['target'] === "") {
+    unset($attributes['target']);
+   } 
+   $menu_link_attributes[$attribute_group] = array_filter($attributes);
   }
 
   $menu_link_attributes = array_filter($menu_link_attributes);


### PR DESCRIPTION
This is a an issue that was closed before but has reappeared. 
https://github.com/yannickoo/menu_link_attributes/issues/11
