### PR TITLE
Add a basic configuration schema.

### DIFF
--- a/config/schema/menu_link_attributes.schema.yml
+++ b/config/schema/menu_link_attributes.schema.yml
@@ -1,0 +1,23 @@
+menu_link_attributes.config:
+  type: config_object
+  mapping:
+    attributes:
+      type: sequence
+      label: 'Attributes'
+      sequence:
+        type: _menu_link_attributes.attribute
+        label: 'An attribute'
+
+_menu_link_attributes.attribute:
+    type: mapping
+    mapping:
+      label:
+        type: string
+      description:
+        type: string
+      type:
+        type: string
+      options:
+        type: sequence
+        sequence:
+          type: string


### PR DESCRIPTION
This adds a basic configuration schema, so Drupal core's `ConfigSchemaChecker` can successfully validate this module's configuration, which happens during every integration test, for example. Those fail without these schemas.