### PR TITLE
Recursively merge options for menu attributes

### DIFF
--- a/menu_link_attributes.module
+++ b/menu_link_attributes.module
@@ -142,7 +142,7 @@ function menu_link_attributes_menu_link_content_form_submit($form, FormStateInte
   }
 
   $menu_link_attributes = array_filter($menu_link_attributes);
-  $menu_link_options = array_merge($menu_link_options, $menu_link_attributes);
+  $menu_link_options = array_merge_recursive($menu_link_options, $menu_link_attributes);
 
   if (count($menu_link_attributes)) {
     $menu_link->link->first()->options = $menu_link_options;


### PR DESCRIPTION
Fix for issue https://github.com/yannickoo/menu_link_attributes/issues/55

I am using module Micon and Menu Link Attributes. On saving a menu link with a Micon icon and additional custom classes, the 'data-icon' is not Micon saved.

You can test the results at 3v4l.org: https://3v4l.org/ACQmG