### PR TITLE
Provide attribute default value.

### DIFF
--- a/config/install/menu_link_attributes.config.yml
+++ b/config/install/menu_link_attributes.config.yml
@@ -8,3 +8,4 @@ attributes:
     options:
       _blank: 'New window (_blank)'
       _self: 'Same window (_self)'
+    default_value: ''

--- a/config/schema/menu_link_attributes.schema.yml
+++ b/config/schema/menu_link_attributes.schema.yml
@@ -21,3 +21,5 @@ _menu_link_attributes.attribute:
         type: sequence
         sequence:
           type: string
+      default_value:
+        type: string

--- a/menu_link_attributes.module
+++ b/menu_link_attributes.module
@@ -90,7 +90,9 @@ function menu_link_attributes_form_menu_link_content_form_alter(array &$form, Fo
       '#type' => $type,
       '#title' => $info['label'],
       '#description' => $info['description'],
-      '#default_value' => isset($menu_link_options[$attributes_key][$attribute_formatted]) ? $menu_link_options[$attributes_key][$attribute_formatted] : '',
+      '#default_value' => isset($menu_link_options[$attributes_key][$attribute_formatted]) ?
+          $menu_link_options[$attributes_key][$attribute_formatted] :
+          (isset($info['default_value']) ? $info['default_value'] : ''),
     ];
 
     // Fill options if select list.


### PR DESCRIPTION
Fixes #70.
To provide a default value for an attribute, use the `default_value` property. Note that there is no validation that the default_value exists in the options.