### PR TITLE
Dependency namespacing in .info.yml file

### DIFF
--- a/menu_link_attributes.info.yml
+++ b/menu_link_attributes.info.yml
@@ -3,5 +3,5 @@ type: module
 description: 'Allows you to add attributes to menu links.'
 core: 8.x
 dependencies:
-  - menu_link_content
+  - drupal:menu_link_content
 configure: menu_link_attributes.config


### PR DESCRIPTION
According to Drupal standards, modules should include dependencies in the .info.yml file. Dependencies should be namespaced in the format {project}:{module}, where {project} is the project name as it appears in the Drupal.org URL (e.g. drupal.org/project/views) and {module} is the module's machine name.
https://www.drupal.org/docs/8/creating-custom-modules/let-drupal-8-know-about-your-module-with-an-infoyml-file Patch to follow, thanks!
